### PR TITLE
Only store non-virtual schema fields in version.

### DIFF
--- a/priv/repo/migrations/20220329132501_create_post_comments.exs
+++ b/priv/repo/migrations/20220329132501_create_post_comments.exs
@@ -1,0 +1,12 @@
+defmodule Postgres.Repo.Migrations.CreatePostComments do
+  use Ecto.Migration
+
+  def change do
+    create table(:post_comments) do
+      add :content, :string
+      add :post_id, references(:posts)
+
+      timestamps()
+    end
+  end
+end

--- a/test/support/post_comment.ex
+++ b/test/support/post_comment.ex
@@ -1,0 +1,19 @@
+defmodule PostComment do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "post_comments" do
+    field(:content, :string)
+    field(:virtual, :string, virtual: true)
+
+    belongs_to(:post, Post)
+
+    timestamps()
+  end
+
+  def changeset(post, attrs) do
+    post
+    |> cast(attrs, [:content])
+    |> validate_required([:content, :post_id])
+  end
+end


### PR DESCRIPTION
Hello.

I appreciate your effort to create a versioning library with a small footprint.

However the code raises some runtime errors when trying to version a schema with relationships.

In the test model `PostComment` has a `belongs_to` relationship to `Post`. The Ecto schema creates a `post` field that fails in 2 ways depending on the situation.

When the comment has a `post_id` but the post hasn't been preloaded, `EctoCellar.store/2` raises with 

> ** (RuntimeError) cannot encode association :post from PostComment to JSON because the association was not loaded.
>
>You can either preload the association:
>
>        Repo.preload(PostComment, :post)
>
>Or choose to not encode the association when converting the struct to JSON by explicitly listing the JSON fields in your schema:
>
>        defmodule PostComment do
>          # ...
>
>          @derive {Jason.Encoder, only: [:name, :title, ...]}
>          schema ... do

and when the post is preloaded it raises with:

>** (Protocol.UndefinedError) protocol Jason.Encoder not implemented for %Post{__meta__: #Ecto.Schema.Metadata<:loaded, "posts">, id: 111, inserted_at: ~N[2022-03-29 14:38:02], title: "title", updated_at: ~N[2022-03-29 14:38:02], views: 0} of type Post (a struct), Jason.Encoder protocol must always be explicitly implemented.
>
>If you own the struct, you can derive the implementation specifying which fields should be encoded to JSON:
>...

I would like to submit these changes under the assumption that versioning a schema is only meant to capture the local state, and I leverage that by retrospecting the local schema fields. This also has the consequence of ignoring virtual fields, which I also believe are not meant to be versioned. Please let me know if this is not your intention so we can discuss it further.

We can safely rely on this API as it is clearly documented in https://hexdocs.pm/ecto/Ecto.Schema.html#module-reflection

The PR example is for a `belongs_to` association, but the errors also exist when the schema contains `has_one` and `has_many` associations. These types of associations have the consequence that versioning a schema also captures all the models that happen to reference it at that time. For example, if a post has many comments, and the comments are preloaded on the post, then when storing the post with EctoCellar, the list of related comments existing at the time would also be stored.