### PR TITLE
Fix broken link to hexdocs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Inspired by [paper_trail](https://github.com/paper-trail-gem/paper_trail).
 
 ## Documentation
 
-This is the user guide. See also, the [API reference](https://hexdocs.pm/ecto_cella).
+This is the user guide. See also, the [API reference](https://hexdocs.pm/ecto_cellar).
 
 ## Installation
 


### PR DESCRIPTION
This looks like a great project and I'm excited to see it take off. This PR fixes one very small typo in the README that breaks the link to the API reference.